### PR TITLE
It's called uMod now apparently...

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,11 +12,11 @@ MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g'
 echo ":/home/container$ ${MODIFIED_STARTUP}"
 
 if [ -f OXIDE_FLAG ] || [ "${OXIDE}" = 1 ]; then
-    echo "Updating OxideMod..."
-    curl -sSL "https://github.com/OxideMod/Oxide/releases/download/latest/Oxide-Rust.zip" > oxide.zip
+    echo "Updating uMod..."
+    curl -sSL "https://umod.org/games/rust/download" > oxide.zip
     unzip -o -q oxide.zip
     rm oxide.zip
-    echo "Done updating OxideMod!"
+    echo "Done updating uMod!"
 fi
 
 # Fix for Rust not starting

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g'
 echo ":/home/container$ ${MODIFIED_STARTUP}"
 
 # OxideMod has been replaced with uMod
-if [ -f OXIDE_FLAG ] || [ "${OXIDE}" = 1 ] || [ "${UMOD}" == 1 ]; then
+if [ -f OXIDE_FLAG ] || [ "${OXIDE}" = 1 ] || [ "${UMOD}" = 1 ]; then
     echo "Updating uMod..."
     curl -sSL "https://umod.org/games/rust/download" > umod.zip
     unzip -o -q umod.zip

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,12 +11,13 @@ export INTERNAL_IP=`ip route get 1 | awk '{print $NF;exit}'`
 MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 echo ":/home/container$ ${MODIFIED_STARTUP}"
 
-if [ -f OXIDE_FLAG ] || [ "${OXIDE}" = 1 ]; then
-    echo "Updating uMod..."
-    curl -sSL "https://umod.org/games/rust/download" > oxide.zip
-    unzip -o -q oxide.zip
-    rm oxide.zip
-    echo "Done updating uMod!"
+# OxideMod has been replaced with uMod
+if [ -f OXIDE_FLAG ] || [ "${OXIDE}" = 1 ] || [ "${UMOD}" == 1 ]; then
+    echo "Updating OxideMod..."
+    curl -sSL "https://github.com/OxideMod/Oxide/releases/download/latest/Oxide-Rust.zip" > umod.zip
+    unzip -o -q umod.zip
+    rm umod.zip
+    echo "Done updating OxideMod!"
 fi
 
 # Fix for Rust not starting

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,11 +13,11 @@ echo ":/home/container$ ${MODIFIED_STARTUP}"
 
 # OxideMod has been replaced with uMod
 if [ -f OXIDE_FLAG ] || [ "${OXIDE}" = 1 ] || [ "${UMOD}" == 1 ]; then
-    echo "Updating OxideMod..."
-    curl -sSL "https://github.com/OxideMod/Oxide/releases/download/latest/Oxide-Rust.zip" > umod.zip
+    echo "Updating uMod..."
+    curl -sSL "https://umod.org/games/rust/download" > umod.zip
     unzip -o -q umod.zip
     rm umod.zip
-    echo "Done updating OxideMod!"
+    echo "Done updating uMod!"
 fi
 
 # Fix for Rust not starting


### PR DESCRIPTION
When updating OxideMod servers, it creates a file called "oxide.txt" with the following content:
```
Downloads for Oxide are not longer provided nor updated at https://github.com/oxidemod/oxide/releases
Please use the the individual repositories or the direct URLs provided by umod.org.
An index of all available game builds: https://umod.org/games

For stable builds/releases:
 - https://umod.org/games/rust/download

For development/unstable builds:
 - https://umod.org/games/rust/download/develop
```

Apparently OxideMod is now called uMod. I may need to update the egg to reflect that as well.