### PR TITLE
Add fontconfig to dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM openjdk:8-jdk-alpine
 
 MAINTAINER Pterodactyl Software, <support@pterodactyl.io>
 
-RUN apk add --no-cache --update curl ca-certificates openssl git tar bash sqlite \
+RUN apk add --no-cache --update curl ca-certificates openssl git tar bash sqlite fontconfig \
     && adduser -D -h /home/container container
 
 USER container


### PR DESCRIPTION
Some plugins that deal with rendering fonts might throw a nasty error since it's a headless JDK, supposedly installing this package fixes the issue.
An example of the issue can be found here: https://hastebin.com/tegasuwedo.rb