### PR TITLE
Add libgdiplus package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Isaac A., <isaac@isaacs.site>
 
 RUN apt update \
     && apt upgrade -y \
-    && apt install -y lib32gcc1 lib32stdc++6 unzip curl iproute2 \
+    && apt install -y lib32gcc1 lib32stdc++6 unzip curl iproute2 libgdiplus \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt install -y nodejs \
     && mkdir /node_modules \


### PR DESCRIPTION
add libgdiplus to the apt install, to fix issues with certain uMod plugins that require it for image manulption.
There are quite a few plugins that need this lib on the system to work otherwise they crash rust or cause the plugin to unload. 