### PR TITLE
fix java timezone stupidity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ FROM openjdk:8-jdk-alpine
 MAINTAINER Pterodactyl Software, <support@pterodactyl.io>
 
 RUN apk add --no-cache --update curl ca-certificates openssl git tar bash sqlite fontconfig \
-    && adduser -D -h /home/container container
-
+ && adduser -D -h /home/container container \
+ && ln -s /etc/localtime /etc/timezone
+ 
 USER container
 ENV  USER=container HOME=/home/container
 


### PR DESCRIPTION
Java uses /etc/timezone but we are looping in /etc/localtime.
This just creates a symlink that fixes it.