### PR TITLE
Update Entrypoint for linux umod rust

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ echo ":/home/container$ ${MODIFIED_STARTUP}"
 # OxideMod has been replaced with uMod
 if [ -f OXIDE_FLAG ] || [ "${OXIDE}" = 1 ] || [ "${UMOD}" = 1 ]; then
     echo "Updating uMod..."
-    curl -sSL "https://umod.org/games/rust/download" > umod.zip
+    curl -sSL "https://umod.org/games/rust/download/develop" > umod.zip
     unzip -o -q umod.zip
     rm umod.zip
     echo "Done updating uMod!"


### PR DESCRIPTION
Umod has split the builds into windows and linux builds now, this url update changes the old windows url to the new linux url as documented on https://umod.org/games/rust