### PR TITLE
add bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.md
+++ b/.github/ISSUE_TEMPLATE/bugs.md
@@ -1,0 +1,17 @@
+---
+name: "\U0001F41B Bug Report"
+about: Report an issue for an image
+
+---
+
+Please fill out the information bellow and remove from the line up  
+If you just submit a bug with no info I will close out your bug.
+---------------
+
+Panel Version: (version number)
+Daemon Version: (version number)
+Service: (minecraft/factorio/etc)
+Docker Image:
+Modified: (yes/no) (did you add or change things, this includes startup configs/install scripts/variables)
+
+Errors that you are experiencing:


### PR DESCRIPTION
Adding a bug template so people may actually give us information.

#52 is an example as to why this is needed.