### PR TITLE
Improve the rust image's wrapper

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -22,7 +22,13 @@ if (startupCmd.length < 1) {
 
 var exec = require("child_process").exec;
 console.log("Starting Rust...");
-exec(startupCmd);
+
+const gameProcess = exec(startupCmd);
+gameProcess.stdout.on('data', console.log);
+gameProcess.stderr.on('data', console.log);
+gameProcess.on('exit', function (code, signal) {
+    process.exit(code);
+});
 
 var waiting = true;
 

--- a/wrapper.js
+++ b/wrapper.js
@@ -39,7 +39,7 @@ console.log("Starting Rust...");
 var exited = false;
 const gameProcess = exec(startupCmd);
 gameProcess.stdout.on('data', filter);
-gameProcess.stderr.on('data', console.log);
+gameProcess.stderr.on('data', filter);
 gameProcess.on('exit', function (code, signal) {
     exited = true;
 
@@ -91,6 +91,8 @@ var poll = function( ) {
         ws.send(createPacket('status'));
 
         process.stdin.removeListener('data', initialListener);
+        gameProcess.stdout.removeListener('data', filter);
+        gameProcess.stderr.removeListener('data', filter);
         process.stdin.on('data', function (text) {
             ws.send(createPacket(text));
         });


### PR DESCRIPTION
This PR improves the rust wrapper by piping stdout and stderr of the rust process into the console, allowing the user to see what is happening during the server load. It also allows the server to be stopped in the middle of its startup, and shows error message about RCON not being in a ready state when attempting to run commands before the process is ready to accept them.

I've also pushed `quay.io/trixterthetux/pterodactyl-eggs:rust` for easy testing.