### PR TITLE
Configurable RCON IP

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -79,7 +79,7 @@ var poll = function( ) {
         return JSON.stringify(packet);
     }
 
-    var serverHostname = "localhost";
+    var serverHostname = process.env.RCON_IP ? process.env.RCON_IP : "localhost";
     var serverPort = process.env.RCON_PORT;
     var serverPassword = process.env.RCON_PASS;
     var WebSocket = require("ws");


### PR DESCRIPTION
This pull request adds the ability to configure an RCON IP via environment variable "RCON_IP". If there is no RCON_IP then it will revert to the default which is "localhost".

Without this, specifically on the host network (not pterodactyl_nw), the container tries to connect to the RCON via localhost, which is the wrong socket. It will then error and keep erroring and spamming the "Waiting for RCON to come up..." message in the console.