### PR TITLE
Update Java from version 8 to 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Environment: Java (glibc support)
 # Minimum Panel Version: 0.6.0
 # ----------------------------------
-FROM        openjdk:8-jre-slim
+FROM        openjdk:11-jre-slim
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 


### PR DESCRIPTION
Paper will soon stop supporting Java 8 soon. The source image needs to be updated to a minimum of Java 11.