### PR TITLE
Update Java 11 to Allow Bash Expressions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ java -version
 export INTERNAL_IP=`ip route get 1 | awk '{print $NF;exit}'`
 
 # Replace Startup Variables
-MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+MODIFIED_STARTUP=`eval echo $(echo '${STARTUP}' | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 echo ":/home/container$ ${MODIFIED_STARTUP}"
 
 # Run the Server


### PR DESCRIPTION
This PR places single quotes around an instance of ${STARTUP}, allowing for bash expressions in the startup command. I made the PR because I tried to set my startup command to

`if [[ {{ALLOCATED_MEMORY}} -le {{SERVER_MEMORY}} ]]; then java -Xms{{ALLOCATED_MEMORY}}M -Xmx{{ALLOCATED_MEMORY}}M -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true -Duser.timezone={{SERVER_TIMEZONE}} -jar {{SERVER_JARFILE}}; fi`
but it kept giving me a syntax error. It works fine under the new code without breaking anything.

Here's both entrypoint.sh files next to each other. The one with single quotes around ${STARTUP} works whereas the other does not.
![image](https://user-images.githubusercontent.com/43528123/107104624-1823b900-67e8-11eb-99f7-5ef423306a13.png)
