### PR TITLE
Update Java 8 to Allow Bash Expressions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ java -version
 export INTERNAL_IP=`ip route get 1 | awk '{print $NF;exit}'`
 
 # Replace Startup Variables
-MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+MODIFIED_STARTUP=`eval echo $(echo '${STARTUP}' | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 echo ":/home/container$ ${MODIFIED_STARTUP}"
 
 # Run the Server


### PR DESCRIPTION
Similar to #71 but for Java 8 in addition to Java 11. I tried putting this on the same PR as Java 11 but couldn't figure out how to.