### PR TITLE
Resolve Rust container timezone issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL       author="Isaac A." maintainer="isaac@isaacs.site"
 
 RUN apt update \
     && apt upgrade -y \
-    && apt install -y lib32gcc1 lib32stdc++6 unzip curl iproute2 libgdiplus \
+    && apt install -y lib32gcc1 lib32stdc++6 unzip curl iproute2 tzdata libgdiplus \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt install -y nodejs npm \
     && mkdir /node_modules \


### PR DESCRIPTION
Installs tzdata package to correctly reflect the configured Wings TZ environment variable. Otherwise, the timezone would be stuck on UTC