### PR TITLE
fix(image): more user-friendly Rust RCON log message

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -86,7 +86,7 @@ var poll = function( ) {
     var ws = new WebSocket("ws://" + serverHostname + ":" + serverPort + "/" + serverPassword);
 
     ws.on("open", function open() {
-        console.log("Connected to RCON.");
+        console.log("Connected to RCON. Generating the map now.");
         waiting = false;
 
         // Hack to fix broken console output

--- a/wrapper.js
+++ b/wrapper.js
@@ -86,7 +86,7 @@ var poll = function( ) {
     var ws = new WebSocket("ws://" + serverHostname + ":" + serverPort + "/" + serverPassword);
 
     ws.on("open", function open() {
-        console.log("Connected to RCON. Generating the map now.");
+        console.log("Connected to RCON. Please wait until the server status switches to \"Running\".");
         waiting = false;
 
         // Hack to fix broken console output


### PR DESCRIPTION
Hopefully reduces the "why is server stuck on Connected to RCON"  questions because the wrapper cuts any stdout including map generation logs until the server has started (too lazy to refactor the wrapper right now)